### PR TITLE
Update for import-processing-functions.php

### DIFF
--- a/includes/import-processing-functions.php
+++ b/includes/import-processing-functions.php
@@ -54,7 +54,9 @@ function epl_jupix_import_price_qualifier( $price_qualifier , $price ) {
  * Processing Function for property_sold_stc
  *
  * @import_usage	[epl_jupix_import_sold_stc({availability[1]})]
- * @return		If price qualifier is 0 returns empty, else returns formatted preice prefix and formatted currency
+ * @return		If XML <availability> = 4 (Sold STC) return 'yes' otherwise 'no'
+ * NOTE:                20181119 At the moment if using "EPL Templates" this creates an issue with properties
+ *                        <availability>5 (Sold) as it shows the properties at (New) which is wrong.
  *
  */
 function epl_jupix_import_sold_stc( $availability ) {


### PR DESCRIPTION
The function epl_jupix_import_sold_stc has the wrong description.

The function epl_jupix_import_sold_stc also if used with "EPL Templates" and "WP All Import Pro" against <availability> returns 'No' when the property is 'Sold' which is fine, except that it shows the property on the front end as 'NEW' - This needs fixing!!